### PR TITLE
Gnome 44 support

### DIFF
--- a/smart-auto-move@khimaros.com/metadata.json
+++ b/smart-auto-move@khimaros.com/metadata.json
@@ -6,6 +6,6 @@
   "settings-schema": "org.gnome.shell.extensions.smart-auto-move",
   "settings-path": "/org/gnome/shell/extensions/smart-auto-move/",
   "original-author": "khimaros",
-  "version": "17",
-  "shell-version": ["41", "42", "43"]
+  "version": "18",
+  "shell-version": ["41", "42", "43", "44"]
 }


### PR DESCRIPTION
Hello and thank you for this very interesting extension! :heart: 

I upgraded today to the latest Fedora and I tested out the extensions that were not yet added for Gnome 44.

- Executed the manual tests from readme and they passed.

The Firefox multi window/workspace use case didn't work from the first try. After closing both windows from the dash, opening it the second time restored the windows with the proper urls, position and workspace. Doing it several times mostly worked fine, there was a miss or two when the windows were not on the expected workspaces, but their positions and urls were ok.

- No js errors were observed in journalctl.

- Bumped metadata version number.

Please submit a new package to https://extensions.gnome.org/ so other 44 folks might enjoy its coolness :sunglasses: 

Thanks!